### PR TITLE
Dma api

### DIFF
--- a/driver/linux/crystalhd_lnx.c
+++ b/driver/linux/crystalhd_lnx.c
@@ -667,11 +667,11 @@ static int __init chd_dec_pci_probe(struct pci_dev *pdev,
 	}
 
 	/* Set dma mask... */
-	if (!pci_set_dma_mask(pdev, DMA_BIT_MASK(64))) {
-		pci_set_consistent_dma_mask(pdev, DMA_BIT_MASK(64));
+	if (!dma_set_mask(dev, DMA_BIT_MASK(64))) {
+		dma_set_coherent_mask(dev, DMA_BIT_MASK(64));
 		pinfo->dmabits = 64;
-	} else if (!pci_set_dma_mask(pdev, DMA_BIT_MASK(32))) {
-		pci_set_consistent_dma_mask(pdev, DMA_BIT_MASK(32));
+	} else if (!dma_set_mask(dev, DMA_BIT_MASK(32))) {
+		dma_set_coherent_mask(dev, DMA_BIT_MASK(32));
 		pinfo->dmabits = 32;
 	} else {
 		dev_err(dev, "%s: Unabled to setup DMA %d\n", __func__, rc);

--- a/driver/linux/crystalhd_lnx.h
+++ b/driver/linux/crystalhd_lnx.h
@@ -83,7 +83,7 @@ struct crystalhd_adp {
 	struct crystalhd_cmd	cmds;
 
 	struct crystalhd_dio_req	*ua_map_free_head;
-	struct pci_pool		*fill_byte_pool;
+	struct dma_pool		*fill_byte_pool;
 };
 
 

--- a/driver/linux/crystalhd_misc.c
+++ b/driver/linux/crystalhd_misc.c
@@ -654,7 +654,11 @@ BC_STATUS crystalhd_map_dio(struct crystalhd_adp *adp, void *ubuff,
 		}
 	}
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,9,0)
+	mmap_read_lock(current->mm);
+#else
 	down_read(&current->mm->mmap_sem);
+#endif
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,9,0)
 	res = get_user_pages(uaddr, nr_pages, rw == READ ? FOLL_WRITE : 0,
@@ -667,7 +671,11 @@ BC_STATUS crystalhd_map_dio(struct crystalhd_adp *adp, void *ubuff,
 			     0, dio->pages, NULL);
 #endif
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,9,0)
+	mmap_read_unlock(current->mm);
+#else
 	up_read(&current->mm->mmap_sem);
+#endif
 
 	/* Save for release..*/
 	dio->sig = crystalhd_dio_locked;

--- a/driver/linux/crystalhd_misc.c
+++ b/driver/linux/crystalhd_misc.c
@@ -724,7 +724,7 @@ BC_STATUS crystalhd_map_dio(struct crystalhd_adp *adp, void *ubuff,
 #endif
 	}
 	dio->sg_cnt = dma_map_sg(&adp->pdev->dev, dio->sg,
-				 dio->page_cnt, (enum dma_data_direction)dio->direction);
+				 dio->page_cnt, dio->direction);
 	if (dio->sg_cnt <= 0) {
 		dev_err(dev, "sg map %d-%d\n", dio->sg_cnt, dio->page_cnt);
 		crystalhd_unmap_dio(adp, dio);
@@ -782,7 +782,7 @@ BC_STATUS crystalhd_unmap_dio(struct crystalhd_adp *adp, struct crystalhd_dio_re
 		}
 	}
 	if (dio->sig == crystalhd_dio_sg_mapped)
-		dma_unmap_sg(&adp->pdev->dev, dio->sg, dio->page_cnt, (enum dma_data_direction)dio->direction);
+		dma_unmap_sg(&adp->pdev->dev, dio->sg, dio->page_cnt, dio->direction);
 
 	crystalhd_free_dio(adp, dio);
 

--- a/driver/linux/crystalhd_misc.h
+++ b/driver/linux/crystalhd_misc.h
@@ -83,7 +83,7 @@ struct crystalhd_dio_req {
 	struct scatterlist				*sg;
 	int								sg_cnt;
 	int								page_cnt;
-	int								direction;
+	enum dma_data_direction						direction;
 	struct crystalhd_dio_user_info	uinfo;
 	void							*fb_va;
 	uint32_t						fb_size;


### PR DESCRIPTION
This patch fix compilation with 5.18 kernel and was (only) build time tested on el7>el9 (3.10~/4.18~/5.14) and current fedoras kernels (up to 6.0-rc2).

Still needs to be runtime tested... 